### PR TITLE
Calendar href test

### DIFF
--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -17,4 +17,12 @@ test.describe('testing react app', () => {
   test('should render Sky website text', async ({ page }) => {
     await expect(page.locator('text=Sky website')).toBeVisible();
   });
+
+  test('Team Calendar is displayed as link on app page', async ({ page }) => {
+    const calendarText = await page.locator('text=Team Calendar');
+    await expect(calendarText).toHaveAttribute(
+      'href',
+      'https://wiki.at.sky/display/LT/Digital+Service+Test+-+Team+Calendar'
+    );
+  });
 });


### PR DESCRIPTION
Test to assert that the calendar text displayed on the app page has the correct href 